### PR TITLE
GameList is now dynamic, UI changes when players added in DB

### DIFF
--- a/app/src/androidTest/java/sdp/moneyrun/MenuActivityTest.java
+++ b/app/src/androidTest/java/sdp/moneyrun/MenuActivityTest.java
@@ -148,6 +148,7 @@ public class MenuActivityTest {
         }
     }
 
+    @Test
     public void newGameEmptyNameFieldError() {
         try (ActivityScenario<MenuActivity> scenario = ActivityScenario.launch(MenuActivity.class)) {
             Intents.init();

--- a/app/src/androidTest/java/sdp/moneyrun/MenuActivityTest.java
+++ b/app/src/androidTest/java/sdp/moneyrun/MenuActivityTest.java
@@ -146,7 +146,6 @@ public class MenuActivityTest {
         if(!dbGames.isSuccessful()){
             fail();
         }
-
         int visibleGames = 0;
         for(DataSnapshot d : dbGames.getResult().getChildren()){
             if(d.child("isVisible").getValue(Boolean.class)){
@@ -157,69 +156,21 @@ public class MenuActivityTest {
         playerList.add(new Player(5,"Aragon", "Epfl",0,0,0));
         try (ActivityScenario<MenuActivity> scenario = ActivityScenario.launch(MenuActivity.class)) {
             Intents.init();
-
             onView(ViewMatchers.withId(R.id.join_game)).perform(ViewActions.click());
             onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
             onView(ViewMatchers.withId(visibleGames-1)).perform(ViewActions.scrollTo());
-
-
             game.setPlayers(playerList, false);
-            Thread.sleep(3000);
+            Thread.sleep(2000);
             onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
             playerList.add(new Player(6,"Heimdalr", "Epfl",0,0,0));
             game.setPlayers(playerList, false);
-            Thread.sleep(3000);
+            Thread.sleep(2000);
             onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
             Intents.release();
-        }catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    }
-    
-/*
-    @Test
-    public void joinGamePopupPlayerButtonIsDisabledWhenTooManyPlayers() {
-        GameDatabaseProxy gdp = new GameDatabaseProxy();
-        Game game = getGame();
-        gdp.putGame(game);
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        //To get the Button ID of the button corresponding to this Game, we have
-        //to get all the games in the DB, and find out how many are visible, aka
-        //how many have buttons since thats how the ids are given out. Tedious but necessary.
-        Task<DataSnapshot> dbGames = FirebaseDatabase.getInstance().getReference().child("games").get();
-        try {
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        if(!dbGames.isSuccessful()){
+        }catch (Exception e) {
             fail();
         }
-
-        int visibleGames = 0;
-        for(DataSnapshot d : dbGames.getResult().getChildren()){
-            if(d.child("isVisible").getValue(Boolean.class)){
-                visibleGames += 1;
-            }
-        }
-        try (ActivityScenario<MenuActivity> scenario = ActivityScenario.launch(MenuActivity.class)) {
-            Intents.init();
-
-            onView(ViewMatchers.withId(R.id.join_game)).perform(ViewActions.click());
-            Thread.sleep(3000);
-            onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
-            onView(ViewMatchers.withId(visibleGames-1)).perform(ViewActions.scrollTo(), ViewActions.click());
-
-
-            Intents.release();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    }*/
+    }
 
     @Test
     public void mapButtonAndSplashScreenWorks() {

--- a/app/src/androidTest/java/sdp/moneyrun/MenuActivityTest.java
+++ b/app/src/androidTest/java/sdp/moneyrun/MenuActivityTest.java
@@ -175,6 +175,7 @@ public class MenuActivityTest {
             e.printStackTrace();
         }
     }
+    
 /*
     @Test
     public void joinGamePopupPlayerButtonIsDisabledWhenTooManyPlayers() {

--- a/app/src/androidTest/java/sdp/moneyrun/MenuActivityTest.java
+++ b/app/src/androidTest/java/sdp/moneyrun/MenuActivityTest.java
@@ -102,7 +102,8 @@ public class MenuActivityTest {
         List<Coin> coins = new ArrayList<>();
         coins.add(new Coin(0., 0., 1));
         Location location = new Location("LocationManager#GPS_PROVIDER");
-
+        location.setLatitude(37.4219473);
+        location.setLongitude(-122.0840015);
         return new Game(name, host, maxPlayerCount, riddles, coins, location, true);
     }
 
@@ -128,40 +129,6 @@ public class MenuActivityTest {
         GameDatabaseProxy gdp = new GameDatabaseProxy();
         Game game = getGame();
         gdp.putGame(game);
-        /*
-        try {
-            Thread.sleep(4000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        List<Player> playerList = new ArrayList<>();
-        playerList.add(new Player(5,"Aragon", "Epfl",0,0,0));
-        try (ActivityScenario<MenuActivity> scenario = ActivityScenario.launch(MenuActivity.class)) {
-            Intents.init();
-
-            onView(ViewMatchers.withId(R.id.join_game)).perform(ViewActions.click());
-            onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
-
-
-            game.setPlayers(playerList, false);
-            Thread.sleep(3000);
-            onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
-
-            playerList.add(new Player(6,"Heimdalr", "Epfl",0,0,0));
-            game.setPlayers(playerList, false);
-            Thread.sleep(3000);
-            onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
-            Intents.release();
-        }catch (InterruptedException e) {
-            e.printStackTrace();
-        }*/
-    }
-
-    @Test
-    public void joinGamePopupPlayerButtonIsDisabledWhenTooManyPlayers() {
-        GameDatabaseProxy gdp = new GameDatabaseProxy();
-        Game game = getGame();
-        gdp.putGame(game);
         try {
             Thread.sleep(2000);
         } catch (InterruptedException e) {
@@ -169,7 +136,7 @@ public class MenuActivityTest {
         }
         //To get the Button ID of the button corresponding to this Game, we have
         //to get all the games in the DB, and find out how many are visible, aka
-        //how many have buttons
+        //how many have buttons since thats how the ids are given out. Tedious but necessary.
         Task<DataSnapshot> dbGames = FirebaseDatabase.getInstance().getReference().child("games").get();
         try {
             Thread.sleep(10000);
@@ -184,50 +151,21 @@ public class MenuActivityTest {
         for(DataSnapshot d : dbGames.getResult().getChildren()){
             if(d.child("isVisible").getValue(Boolean.class)){
                 visibleGames += 1;
-                Log.d("GAMELISTTEST", "tag of visible :"+d.getKey());
-                Log.d("GAMELISTTEST","tag of uploaded game :"+game.getId());
             }
-
         }
-        Log.d("GAMELISTTEST", "visible: " + visibleGames);
-        /*
-        GenericTypeIndicator<Map<String,DataSnapshot>> t = new GenericTypeIndicator<Map<String,DataSnapshot>>(){};
-        Map<String, DataSnapshot> gamesList;
-        gamesList = dbGames.getResult().getValue(t);
-        for(GameDbData g:gamesList){
-            if(g.getIsVisible()){
-                visibleGames += 1;
-            }
-        }*/
-
-        try (ActivityScenario<MenuActivity> scenario = ActivityScenario.launch(MenuActivity.class)) {
-            Intents.init();
-
-            onView(ViewMatchers.withId(R.id.join_game)).perform(ViewActions.click());
-            onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
-            onView(ViewMatchers.withId(visibleGames)).perform(ViewActions.scrollTo(), ViewActions.click());
-
-
-            Intents.release();
-        }
-
-        /*
-
         List<Player> playerList = new ArrayList<>();
         playerList.add(new Player(5,"Aragon", "Epfl",0,0,0));
-
         try (ActivityScenario<MenuActivity> scenario = ActivityScenario.launch(MenuActivity.class)) {
             Intents.init();
 
             onView(ViewMatchers.withId(R.id.join_game)).perform(ViewActions.click());
-            onView(ViewMatchers.withId());
             onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
+            onView(ViewMatchers.withId(visibleGames-1)).perform(ViewActions.scrollTo());
 
 
             game.setPlayers(playerList, false);
             Thread.sleep(3000);
             onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
-
             playerList.add(new Player(6,"Heimdalr", "Epfl",0,0,0));
             game.setPlayers(playerList, false);
             Thread.sleep(3000);
@@ -235,8 +173,52 @@ public class MenuActivityTest {
             Intents.release();
         }catch (InterruptedException e) {
             e.printStackTrace();
-        }*/
+        }
     }
+/*
+    @Test
+    public void joinGamePopupPlayerButtonIsDisabledWhenTooManyPlayers() {
+        GameDatabaseProxy gdp = new GameDatabaseProxy();
+        Game game = getGame();
+        gdp.putGame(game);
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        //To get the Button ID of the button corresponding to this Game, we have
+        //to get all the games in the DB, and find out how many are visible, aka
+        //how many have buttons since thats how the ids are given out. Tedious but necessary.
+        Task<DataSnapshot> dbGames = FirebaseDatabase.getInstance().getReference().child("games").get();
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        if(!dbGames.isSuccessful()){
+            fail();
+        }
+
+        int visibleGames = 0;
+        for(DataSnapshot d : dbGames.getResult().getChildren()){
+            if(d.child("isVisible").getValue(Boolean.class)){
+                visibleGames += 1;
+            }
+        }
+        try (ActivityScenario<MenuActivity> scenario = ActivityScenario.launch(MenuActivity.class)) {
+            Intents.init();
+
+            onView(ViewMatchers.withId(R.id.join_game)).perform(ViewActions.click());
+            Thread.sleep(3000);
+            onView(ViewMatchers.withId(R.id.join_popup)).check(matches(isDisplayed()));
+            onView(ViewMatchers.withId(visibleGames-1)).perform(ViewActions.scrollTo(), ViewActions.click());
+
+
+            Intents.release();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }*/
 
     @Test
     public void mapButtonAndSplashScreenWorks() {

--- a/app/src/main/java/sdp/moneyrun/game/Game.java
+++ b/app/src/main/java/sdp/moneyrun/game/Game.java
@@ -210,7 +210,7 @@ public class Game {
             FirebaseDatabase.getInstance().getReference()
                     .child(DATABASE_GAME)
                     .child(id)
-                    .child(DATABASE_GAME)
+                    .child(DATABASE_PLAYER)
                     .setValue(players);
         }
     }

--- a/app/src/main/java/sdp/moneyrun/game/GameRepresentation.java
+++ b/app/src/main/java/sdp/moneyrun/game/GameRepresentation.java
@@ -11,7 +11,7 @@ import sdp.moneyrun.map.LocationRepresentation;
 public class GameRepresentation {
     private final String gameId;
     private final String name;
-    private final int playerCount;
+    private  int playerCount;
     private final int maxPlayerCount;
     private final LocationRepresentation startLocation;
 
@@ -73,5 +73,10 @@ public class GameRepresentation {
      */
     public LocationRepresentation getStartLocation(){
         return startLocation;
+    }
+
+    public void setPlayerCount(int t){
+        if(t < 1){ throw new IllegalArgumentException("Tried to set playerCount to " + t + " but it may not be less than 1");}
+        playerCount = t;
     }
 }

--- a/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
+++ b/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
@@ -181,7 +181,7 @@ public class JoinGameImplementation extends MenuImplementation{
         button.setOnClickListener(v -> joinLobbyFromJoinButton(gameRepresentation));
 
         // Modify button if the game is full
-        databaseReference.child(activity.getString(R.string.database_game))
+        /*databaseReference.child(activity.getString(R.string.database_game))
                 .child(gameRepresentation.getGameId()).addValueEventListener(new ValueEventListener() {
             @Override
             public void onDataChange(@NonNull DataSnapshot snapshot) {
@@ -202,7 +202,7 @@ public class JoinGameImplementation extends MenuImplementation{
                 button.setEnabled(false);
                 button.setText("Full");
             }
-        });
+        });*/
 
         // Modify button if game is too far
         // Grant permissions if necessary
@@ -242,7 +242,7 @@ public class JoinGameImplementation extends MenuImplementation{
         playerNumberView.setText(playerNumberText);
 
         //makes the playerCount dynamic so that it changes when people join and leave lobbies
-        databaseReference.child(activity.getString(R.string.database_game)).child(gameRepresentation.getGameId())
+        /*databaseReference.child(activity.getString(R.string.database_game)).child(gameRepresentation.getGameId())
                 .addValueEventListener(new ValueEventListener() {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot snapshot) {
@@ -257,7 +257,7 @@ public class JoinGameImplementation extends MenuImplementation{
                     public void onCancelled(@NonNull DatabaseError error) {
                         Log.e(TAG, "Error getting new Player Count from DB");
                     }
-                });
+                });*/
 
         gameRow.addView(playerNumberView);
     }

--- a/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
+++ b/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
@@ -188,10 +188,10 @@ public class JoinGameImplementation extends MenuImplementation{
                 int newPlayerCount = (int) snapshot.child(activity.getString(R.string.database_open_games_players)).getChildrenCount();
                 if(newPlayerCount >= gameRepresentation.getMaxPlayerCount()){
                     button.setEnabled(false);
-                    button.setText("Full");
+                    button.setText(activity.getResources().getString(R.string.join_game_full_message));
                 }else{
                     button.setEnabled(true);
-                    button.setText("Join");
+                    button.setText(activity.getResources().getString(R.string.join_game_message));
                 }
             }
 
@@ -200,7 +200,7 @@ public class JoinGameImplementation extends MenuImplementation{
                 Log.e(TAG, "Error getting new Player Count from DB");
                 //FailSafe defaults. If we couldnt get the data, let's be safe and close the game
                 button.setEnabled(false);
-                button.setText("Full");
+                button.setText(activity.getResources().getString(R.string.join_game_full_message));
             }
         });
 

--- a/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
+++ b/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
@@ -181,7 +181,7 @@ public class JoinGameImplementation extends MenuImplementation{
         button.setOnClickListener(v -> joinLobbyFromJoinButton(gameRepresentation));
 
         // Modify button if the game is full
-        /*databaseReference.child(activity.getString(R.string.database_game))
+        databaseReference.child(activity.getString(R.string.database_game))
                 .child(gameRepresentation.getGameId()).addValueEventListener(new ValueEventListener() {
             @Override
             public void onDataChange(@NonNull DataSnapshot snapshot) {
@@ -202,7 +202,7 @@ public class JoinGameImplementation extends MenuImplementation{
                 button.setEnabled(false);
                 button.setText("Full");
             }
-        });*/
+        });
 
         // Modify button if game is too far
         // Grant permissions if necessary
@@ -242,7 +242,7 @@ public class JoinGameImplementation extends MenuImplementation{
         playerNumberView.setText(playerNumberText);
 
         //makes the playerCount dynamic so that it changes when people join and leave lobbies
-        /*databaseReference.child(activity.getString(R.string.database_game)).child(gameRepresentation.getGameId())
+        databaseReference.child(activity.getString(R.string.database_game)).child(gameRepresentation.getGameId())
                 .addValueEventListener(new ValueEventListener() {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot snapshot) {
@@ -257,7 +257,7 @@ public class JoinGameImplementation extends MenuImplementation{
                     public void onCancelled(@NonNull DatabaseError error) {
                         Log.e(TAG, "Error getting new Player Count from DB");
                     }
-                });*/
+                });
 
         gameRow.addView(playerNumberView);
     }

--- a/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
+++ b/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
@@ -242,8 +242,7 @@ public class JoinGameImplementation extends MenuImplementation{
         playerNumberView.setText(playerNumberText);
 
         //makes the playerCount dynamic so that it changes when people join and leave lobbies
-        databaseReference.child(activity.getString(R.string.database_game)).child(gameRepresentation.getGameId())
-                .addValueEventListener(new ValueEventListener() {
+        databaseReference.child(activity.getString(R.string.database_game)).child(gameRepresentation.getGameId()).addValueEventListener(new ValueEventListener() {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot snapshot) {
                         int newPlayerCount = (int) snapshot.child(activity.getString(R.string.database_open_games_players)).getChildrenCount();

--- a/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
+++ b/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
@@ -180,6 +180,32 @@ public class JoinGameImplementation extends MenuImplementation{
         button.setText(activity.getString(R.string.join_game_message));
         button.setOnClickListener(v -> joinLobbyFromJoinButton(gameRepresentation));
 
+        //modify button if the game is full or if a space frees up
+        addFullGameListener(button, gameRepresentation);
+
+        // Modify button if game is too far
+        // Grant permissions if necessary
+        requestLocationPermissions(requestPermissionsLauncher);
+
+        fusedLocationClient.getLastLocation()
+                .addOnSuccessListener(activity, location -> {
+                    // Got last known location. In some rare situations this can be null
+                    // In this case, the game cannot be instanciated
+                    if (location == null) {
+                        Log.e("location", "Error getting location");
+                    }
+                    LocationRepresentation locationRep = new LocationRepresentation(location.getLatitude(), location.getLongitude());
+
+                    double distance = gameRepresentation.getStartLocation().distanceTo(locationRep);
+
+                    if (distance > MAX_DISTANCE_TO_JOIN_GAME) {
+                        button.setEnabled(false);
+                        button.setText(activity.getString(R.string.join_game_too_far_message));
+                    }
+                });
+    }
+
+    private void addFullGameListener(Button button, GameRepresentation gameRepresentation) {
         // Modify button if the game is full
         databaseReference.child(activity.getString(R.string.database_game))
                 .child(gameRepresentation.getGameId()).addValueEventListener(new ValueEventListener() {
@@ -203,27 +229,6 @@ public class JoinGameImplementation extends MenuImplementation{
                 button.setText(activity.getResources().getString(R.string.join_game_full_message));
             }
         });
-
-        // Modify button if game is too far
-        // Grant permissions if necessary
-        requestLocationPermissions(requestPermissionsLauncher);
-
-        fusedLocationClient.getLastLocation()
-                .addOnSuccessListener(activity, location -> {
-                    // Got last known location. In some rare situations this can be null
-                    // In this case, the game cannot be instanciated
-                    if (location == null) {
-                        Log.e("location", "Error getting location");
-                    }
-                    LocationRepresentation locationRep = new LocationRepresentation(location.getLatitude(), location.getLongitude());
-
-                    double distance = gameRepresentation.getStartLocation().distanceTo(locationRep);
-
-                    if (distance > MAX_DISTANCE_TO_JOIN_GAME) {
-                        button.setEnabled(false);
-                        button.setText(activity.getString(R.string.join_game_too_far_message));
-                    }
-                });
     }
 
     private void createGameNameInfoDisplay(GameRepresentation gameRepresentation, TableRow gameRow){

--- a/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
+++ b/app/src/main/java/sdp/moneyrun/menu/JoinGameImplementation.java
@@ -14,10 +14,14 @@ import android.widget.TableRow;
 import android.widget.TextView;
 
 import androidx.activity.result.ActivityResultLauncher;
+import androidx.annotation.NonNull;
+
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.ValueEventListener;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +39,7 @@ public class JoinGameImplementation extends MenuImplementation{
 
     private final boolean focusable;
     private final int layoutId;
+    private static final String TAG = JoinGameImplementation.class.getSimpleName();
 
     public JoinGameImplementation(Activity activity,
                                   DatabaseReference databaseReference,
@@ -176,10 +181,28 @@ public class JoinGameImplementation extends MenuImplementation{
         button.setOnClickListener(v -> joinLobbyFromJoinButton(gameRepresentation));
 
         // Modify button if the game is full
-        if (gameRepresentation.getPlayerCount() >= gameRepresentation.getMaxPlayerCount()) {
-            button.setEnabled(false);
-            button.setText(activity.getString(R.string.join_game_full_message));
-        }
+        databaseReference.child(activity.getString(R.string.database_game))
+                .child(gameRepresentation.getGameId()).addValueEventListener(new ValueEventListener() {
+            @Override
+            public void onDataChange(@NonNull DataSnapshot snapshot) {
+                int newPlayerCount = (int) snapshot.child(activity.getString(R.string.database_open_games_players)).getChildrenCount();
+                if(newPlayerCount >= gameRepresentation.getMaxPlayerCount()){
+                    button.setEnabled(false);
+                    button.setText("Full");
+                }else{
+                    button.setEnabled(true);
+                    button.setText("Join");
+                }
+            }
+
+            @Override
+            public void onCancelled(@NonNull DatabaseError error) {
+                Log.e(TAG, "Error getting new Player Count from DB");
+                //FailSafe defaults. If we couldnt get the data, let's be safe and close the game
+                button.setEnabled(false);
+                button.setText("Full");
+            }
+        });
 
         // Modify button if game is too far
         // Grant permissions if necessary
@@ -217,6 +240,25 @@ public class JoinGameImplementation extends MenuImplementation{
                 gameRepresentation.getPlayerCount(),
                 gameRepresentation.getMaxPlayerCount());
         playerNumberView.setText(playerNumberText);
+
+        //makes the playerCount dynamic so that it changes when people join and leave lobbies
+        databaseReference.child(activity.getString(R.string.database_game)).child(gameRepresentation.getGameId())
+                .addValueEventListener(new ValueEventListener() {
+                    @Override
+                    public void onDataChange(@NonNull DataSnapshot snapshot) {
+                        int newPlayerCount = (int) snapshot.child(activity.getString(R.string.database_open_games_players)).getChildrenCount();
+                        String playerNumberText = String.format((activity.getResources().getString(R.string.game_player_number_display)),
+                                newPlayerCount,
+                                gameRepresentation.getMaxPlayerCount());
+                        playerNumberView.setText(playerNumberText);
+                    }
+
+                    @Override
+                    public void onCancelled(@NonNull DatabaseError error) {
+                        Log.e(TAG, "Error getting new Player Count from DB");
+                    }
+                });
+
         gameRow.addView(playerNumberView);
     }
 

--- a/app/src/main/res/layout/activity_game_lobby.xml
+++ b/app/src/main/res/layout/activity_game_lobby.xml
@@ -69,6 +69,7 @@
         android:layout_marginStart="48dp"
         android:layout_marginBottom="90dp"
         android:text="Leave"
+        android:background="#FF392E"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
@@ -79,6 +80,7 @@
         android:layout_marginEnd="56dp"
         android:layout_marginBottom="88dp"
         android:text="Launch game"
+        android:background="#77dd77"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,9 @@
 
     <!-- PLAYER -->
     <string name="database_player">players</string>
+    <string name="database_open_games_players">players</string>
     <string name="database_player_address">address</string>
+    <string name="database_open_games_max_player_number">maxPlayerNumber</string>
     <string name="database_player_name">name</string>
     <string name="database_player_number_of_died_games">numberOfDiedGames</string>
     <string name="database_player_number_of_played_games">numberOfPlayedGames</string>

--- a/app/src/test/java/sdp/moneyrun/GameRepresentationTest.java
+++ b/app/src/test/java/sdp/moneyrun/GameRepresentationTest.java
@@ -75,4 +75,22 @@ public class GameRepresentationTest {
 
         assertEquals(gr.getStartLocation(), lr);
     }
+
+
+    @Test
+    public void setPlayerCountFailsOnLessThanOne(){
+        LocationRepresentation lr = new LocationRepresentation(0, 1);
+        GameRepresentation gr = new GameRepresentation("0", "game", 0, 16, lr);
+        assertThrows(IllegalArgumentException.class, () ->{
+            gr.setPlayerCount(-2);
+        });
+    }
+
+    @Test
+    public void setPlayerCountSetsPlayerCount(){
+        LocationRepresentation lr = new LocationRepresentation(0, 1);
+        GameRepresentation gr = new GameRepresentation("0", "game", 0, 16, lr);
+        gr.setPlayerCount(4);
+        assertEquals(4, gr.getPlayerCount());
+    }
 }


### PR DESCRIPTION
Makes the Join Game List dynamic, as in, if a player joins a Game, now the button on the list will have updated info on the number of players. And if the game fills up, the button to join will become unavailable, dynamically. For now the only way to do this is to add nodes to the "players" child of a Game in the DB. This was part of a bigger PR that couldnt be merged in time for the end of the sprint